### PR TITLE
Add filters to `JsAssignArrayElementsStrategy` to prohibit creation of long destructuring assignments

### DIFF
--- a/tests/longDestructuring.js
+++ b/tests/longDestructuring.js
@@ -1,0 +1,4 @@
+function foo(arr) {
+    var a = arr[0], c = arr[1], b = arr[50];
+    var x = arr[5];
+}

--- a/tests/longDestructuring.out.js
+++ b/tests/longDestructuring.out.js
@@ -1,0 +1,3 @@
+function foo(arr) {
+  var [a, c, , , , x] = arr;
+}


### PR DESCRIPTION
This closes #3